### PR TITLE
Add Jest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ This is the `lawyers.js` module of the [NyayaNext](https://www.nyayanext.com) le
    cd nyayanext-public
 # lawyers-directory
 core module for NyayaNext lawyer onboarding and search
+
+## 🧪 Testing
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Run the test suite:
+   ```bash
+   npm test
+   ```
+
+The test setup uses Jest with a jsdom environment. If `npm test` fails with `jest: command not found`, make sure dependencies were installed correctly.

--- a/__tests__/lawyers.test.js
+++ b/__tests__/lawyers.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LawyersDirectory from '../lawyers';
+
+describe('LawyersDirectory', () => {
+  test('renders provided lawyer info', () => {
+    const lawyers = [
+      { name: 'Alice', city: 'Delhi', phone: '1234567890', specialty: 'Civil' },
+    ];
+    render(<LawyersDirectory initialLawyers={lawyers} />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText(/Delhi/)).toBeInTheDocument();
+    expect(screen.getByText(/1234567890/)).toBeInTheDocument();
+  });
+});

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', {targets: {node: 'current'}}],
+    ['@babel/preset-react']
+  ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "lawyers-directory",
+  "version": "0.1.0",
+  "description": "Lawyers directory module for NyayaNext",
+  "main": "lawyers.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "@babel/preset-env": "^7.22.20",
+    "@babel/preset-react": "^7.18.6",
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/react": "^14.1.2",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}


### PR DESCRIPTION
## Summary
- set up `package.json` with basic dev dependencies and test script
- configure Babel and Jest for React component testing
- add an example test for `lawyers.js`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fe8287fc832bbf0ed5d3c0e8e1c1